### PR TITLE
More difficulty adjustments

### DIFF
--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -166,7 +166,7 @@ food {
     B:modifyHoeUse=true
 
     # Whether wood and stone hoe recipes are removed [vanilla: false] [default: true]
-    B:removeHoeRecipes=true
+    B:removeHoeRecipes=false
 
     # Removes seed drops when breaking tall grass [vanilla: false] [default: true]
     B:removeTallGrassSeeds=true

--- a/config/IguanaTinkerTweaks/main.cfg
+++ b/config/IguanaTinkerTweaks/main.cfg
@@ -23,6 +23,15 @@ allowedtools {
 
     # Here you can exclude entire mods by adding their mod-id (the first part of the string). [default: [minecraft], [Metallurgy], [Natura], [BiomesOPlenty], [ProjRed|Exploration], [appliedenergistics2], [MekanismTool], [ThermalFoundation]]
     S:mods <
+        minecraft
+		BiomesOPlenty
+		Natura
+		MekanismTool
+		Steamcraft
+		Railcraft
+		ThermalFoundation
+		appliedenergistics2
+		bluepower
      >
 
     # Swords that are excluded if the option to nerf non-tinkers swords is enabled. [default: [Botania:manasteelSword], [Steamcraft:swordGildedGold], [Steamcraft:swordBrass], [ThermalExpansion:tool.battleWrenchInvar], [IC2:itemToolBronzeSword], [Railcraft:tool.steel.sword]]
@@ -267,19 +276,19 @@ tweaks {
     B:disableBonusModifierModifiers=false
 
     # Makes all non-TConstruct bows useless. You suddenly forgot how to use a bow. [default: false]
-    B:disableRegularBows=false
+    B:disableRegularBows=true
 
     # Makes all non-TConstruct hoes to not be able to hoe ground. Use the Mattock. [default: false]
-    B:disableRegularHoes=false
+    B:disableRegularHoes=true
 
     # Makes all non-TConstruct swords useless. Like whacking enemies with a stick. [default: false]
-    B:disableRegularSwords=false
+    B:disableRegularSwords=true
 
     # Makes all non-TConstruct tools mine nothing [default: true]
-    B:disableRegularTools=false
+    B:disableRegularTools=true
 
     # Stone Tools can only be used to create casts, but no tools [default: true]
-    B:disableStoneTools=true
+    B:disableStoneTools=false
 
     # Allows to craft tool parts with a pattern and the material in any crafting grid. [default: false]
     B:easyPartCrafting=false
@@ -294,7 +303,7 @@ tweaks {
     B:easyToolRepair=true
 
     # How many gravel are required to craft one Flint [range: 1 ~ 9, default: 3]
-    I:gravelPerFlint=3
+    I:gravelPerFlint=2
 
     # Silky Cloth needs gold ingots, instead of nuggets [default: true]
     B:moreExpensiveSilkyCloth=true

--- a/config/SpiceOfLife.cfg
+++ b/config/SpiceOfLife.cfg
@@ -95,8 +95,11 @@ server {
     # 	cur_saturation : The current saturation value of the player
     # 	total_food_eaten : The all-time total number of times any food has been eaten by the player
     # 
-	#   Easier formula : S:food.modifier.formula=MAX(0, 1 - MAX(0, (count-4)/5))
-    S:food.modifier.formula=MAX(0, (1 - count/12))^MIN(8, food_hunger_value)
+	#   Easy difficulty:  S:food.modifier.formula=MAX(0, 1 - MAX(0, (count-4)/5))
+	#   Normal difficulty:  S:food.modifier.formula=MAX(0, (1 - count/36))^MIN(8, food_hunger_value)
+	#   Hard difficulty:  S:food.modifier.formula=MAX(0, (1 - count/12))^MIN(8, food_hunger_value)
+	S:food.modifier.formula=MAX(0, (1 - count/36))^MIN(8, food_hunger_value)
+    
 
     # If true, a food journal will be given to each player as a starting item
     B:give.food.journal.as.starting.item=false

--- a/config/SpiceOfLife.cfg
+++ b/config/SpiceOfLife.cfg
@@ -44,7 +44,7 @@ server {
 
     # If true, foods with negative hunger values will be made more negative as nutritional value decreases
     # NOTE: affect.food.hunger.values must be true for this to have any affect
-    B:affect.negative.food.hunger.values=false
+    B:affect.negative.food.hunger.values=true
 
     # If true, foods with negative saturation modifiers will be made more negative as nutritional value decreases
     # NOTE: affect.food.saturation.modifiers must be true for this to have any affect
@@ -59,7 +59,7 @@ server {
     D:food.containers.chance.to.drop.food=0.25
 
     # The maximum stacksize per slot in a food container
-    I:food.containers.max.stacksize=2
+    I:food.containers.max.stacksize=5
 
     # The maximum time it takes to eat a food after being modified by food.eating.speed.modifier
     # The default eating duration is 32. Set this to 0 to remove the limit on eating speed.
@@ -103,10 +103,10 @@ server {
 
     # If true, a food journal will be given to each player once diminishing returns start for them
     # Not given if a player was given a food journal by give.food.journal.as.starting.item
-    B:give.food.journal.on.dimishing.returns.start=false
+    B:give.food.journal.on.dimishing.returns.start=true
 
     # The number of times a new player (by World) needs to eat before this mod has any effect
-    I:new.player.food.eaten.threshold=0
+    I:new.player.food.eaten.threshold=20
 
     # If true, any foods not in a food group will be excluded from diminishing returns
     B:use.food.groups.as.whitelists=false


### PR DESCRIPTION
- Made vanilla tools useless via Iguana's (still craftable for thinks
  that use them as crafting components)
- Re-enabled stone tinkers' tools
- Modified gravel-to-flint recipe
- Expanded spice of life food containers due to variety required
- Added new player leeway before hunger becomes an issue, added food
  journal once leeway is passed
- Eating lots of bad food in a row is exceptionally bad (negative hunger
  values from things like zombie flesh get worse each time)
